### PR TITLE
Allow prompt text on BigDecimalFields

### DIFF
--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/BigDecimalFieldSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/BigDecimalFieldSkin.java
@@ -28,8 +28,6 @@
 package jfxtras.labs.internal.scene.control.skin;
 
 import com.sun.javafx.scene.control.skin.SkinBase;
-import java.math.BigDecimal;
-import java.text.ParseException;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.value.ChangeListener;
@@ -43,12 +41,15 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.*;
+import javafx.scene.layout.StackPane;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import jfxtras.labs.internal.scene.control.behavior.BigDecimalFieldBehaviour;
 import jfxtras.labs.scene.control.BigDecimalField;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
 
 /**
  * Skin implementation for {@link BigDecimalField}.
@@ -79,7 +80,7 @@ public class BigDecimalFieldSkin extends SkinBase<BigDecimalField, BigDecimalFie
     private void createNodes() {
         setFocusTraversable(true);
         textField = new NumberTextField();
-
+        initializePromptText();
         //
         // The Buttons are StackPanes with a Path on top
         //
@@ -122,6 +123,20 @@ public class BigDecimalFieldSkin extends SkinBase<BigDecimalField, BigDecimalFie
             }
         });
         
+    }
+
+    private void initializePromptText() {
+        getSkinnable().promptTextProperty().addListener(new ChangeListener<String>() {
+            @Override
+            public void changed(ObservableValue<? extends String> observableValue, String oldText, String newText) {
+                changePromptText();
+            }
+        });
+        changePromptText();
+    }
+
+    private void changePromptText() {
+        textField.setPromptText(getSkinnable().getPromptText());
     }
 
     @Override

--- a/src/main/java/jfxtras/labs/scene/control/BigDecimalField.java
+++ b/src/main/java/jfxtras/labs/scene/control/BigDecimalField.java
@@ -27,20 +27,23 @@
 
 package jfxtras.labs.scene.control;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.Control;
+
 import java.math.BigDecimal;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.control.Control;
 
 /**
  * Input field for BigDecimal values. This control has the following features:
  * - BigDecimal {@link #number} is parsed and formatted according to the provided NumberFormat
- * - up/down arrow keys and buttons increment/decrement the {@link #number} by {@link #stepwidth} 
- * 
+ * - up/down arrow keys and buttons increment/decrement the {@link #number} by {@link #stepwidth}
+ *
  * @author Thomas Bolz
  */
 public class BigDecimalField extends Control {
@@ -52,6 +55,7 @@ public class BigDecimalField extends Control {
         number = new SimpleObjectProperty(this, "number", BigDecimal.ZERO);
         stepwidth = new SimpleObjectProperty(this, "stepwidth", BigDecimal.ONE);
         format = new SimpleObjectProperty(this, "format", NumberFormat.getNumberInstance());
+        promptText = new SimpleStringProperty(this, "promptText", "");
     }
 
     public BigDecimalField(BigDecimal initialValue, BigDecimal stepwidth, NumberFormat format) {
@@ -69,7 +73,6 @@ public class BigDecimalField extends Control {
     }
 
     /**
-     * 
      * @param formattedNumber representation of number
      */
     public void setText(String formattedNumber) {
@@ -94,7 +97,7 @@ public class BigDecimalField extends Control {
     public void decrement() {
         setNumber(getNumber().subtract(getStepwidth()));
     }
-    
+
     final private ObjectProperty<BigDecimal> number;
 
     /**
@@ -133,7 +136,7 @@ public class BigDecimalField extends Control {
     /**
      * stepwidth for inc/dec operation
      */
-    public  void setStepwidth(BigDecimal value) {
+    public void setStepwidth(BigDecimal value) {
         stepwidth.set(value);
     }
 
@@ -143,6 +146,7 @@ public class BigDecimalField extends Control {
     public ObjectProperty<BigDecimal> stepwidthProperty() {
         return stepwidth;
     }
+
     final private ObjectProperty<NumberFormat> format;
 
     public NumberFormat getFormat() {
@@ -157,8 +161,22 @@ public class BigDecimalField extends Control {
         return format;
     }
 
+    final private StringProperty promptText;
+
+    public String getPromptText() {
+        return promptText.getValue();
+    }
+
+    public final void setPromptText(String value) {
+        promptText.setValue(value);
+    }
+
+    public StringProperty promptTextProperty() {
+        return promptText;
+    }
+
     @Override
     protected String getUserAgentStylesheet() {
-        return getClass().getResource("/jfxtras/labs/internal/scene/control/"+getClass().getSimpleName()+".css").toExternalForm();
+        return getClass().getResource("/jfxtras/labs/internal/scene/control/" + getClass().getSimpleName() + ".css").toExternalForm();
     }
 }

--- a/src/main/java/jfxtras/labs/scene/control/BigDecimalField.java
+++ b/src/main/java/jfxtras/labs/scene/control/BigDecimalField.java
@@ -31,6 +31,8 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.scene.control.Control;
 
 import java.math.BigDecimal;
@@ -56,6 +58,12 @@ public class BigDecimalField extends Control {
         stepwidth = new SimpleObjectProperty(this, "stepwidth", BigDecimal.ONE);
         format = new SimpleObjectProperty(this, "format", NumberFormat.getNumberInstance());
         promptText = new SimpleStringProperty(this, "promptText", "");
+        number.addListener(new ChangeListener<BigDecimal>() {
+            @Override
+            public void changed(ObservableValue<? extends BigDecimal> observableValue, BigDecimal oldValue, BigDecimal newValue) {
+                BigDecimalField.this.cleared = false;
+            }
+        });
     }
 
     public BigDecimalField(BigDecimal initialValue, BigDecimal stepwidth, NumberFormat format) {
@@ -69,6 +77,9 @@ public class BigDecimalField extends Control {
      * @return The text representation of number
      */
     public String getText() {
+        if (cleared) {
+            return "";
+        }
         return getFormat().format(number.getValue());
     }
 
@@ -82,6 +93,11 @@ public class BigDecimalField extends Control {
         } catch (ParseException ex) {
             Logger.getLogger(BigDecimalField.class.getName()).log(Level.INFO, null, ex);
         }
+    }
+
+    public void clear() {
+        setNumber(new BigDecimal(0));
+        this.cleared = true;
     }
 
     /**
@@ -98,6 +114,8 @@ public class BigDecimalField extends Control {
         setNumber(getNumber().subtract(getStepwidth()));
     }
 
+
+    private boolean cleared = false;
     final private ObjectProperty<BigDecimal> number;
 
     /**

--- a/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
+++ b/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
@@ -27,11 +27,9 @@
 
 package jfxtras.labs.scene.control;
 
-import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.util.Locale;
 import javafx.application.Application;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
@@ -42,6 +40,11 @@ import javafx.scene.control.LabelBuilder;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  *
@@ -67,6 +70,8 @@ public class BigDecimalFieldDemo extends Application {
         final BigDecimalField decimalFormat = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.05"), new DecimalFormat("#,##0.00"));
         final BigDecimalField percent = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.01"), NumberFormat.getPercentInstance());
         final BigDecimalField localizedCurrency = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.01"), NumberFormat.getCurrencyInstance(Locale.UK));
+        final BigDecimalField promptText = new BigDecimalField();
+        promptText.setPromptText("Enter something");
         Label label1;
         root.addRow(1, new Label("default"), defaultSpinner, label1 = LabelBuilder.create().build());
 //        label1.textProperty().bind(Bindings.convert(defaultSpinner.numberProperty()));
@@ -77,6 +82,14 @@ public class BigDecimalFieldDemo extends Application {
         disabledField.setDisable(true);
         root.addRow(5, new Label("disabled field"), disabledField);
         root.addRow(6, new Label("regular TextField"), new TextField("1.000,1234"));
+        root.addRow(7, new Label("with promptText"), promptText);
+
+        promptText.numberProperty().addListener(new ChangeListener<BigDecimal>() {
+            @Override
+            public void changed(ObservableValue<? extends BigDecimal> observableValue, BigDecimal o, BigDecimal o1) {
+                System.out.println(o1);
+            }
+        });
 
         Button button = new Button("Reset fields");
         button.setOnAction(new EventHandler<ActionEvent>() {

--- a/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
+++ b/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
@@ -72,6 +72,7 @@ public class BigDecimalFieldDemo extends Application {
         final BigDecimalField localizedCurrency = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.01"), NumberFormat.getCurrencyInstance(Locale.UK));
         final BigDecimalField promptText = new BigDecimalField();
         promptText.setPromptText("Enter something");
+        promptText.clear();
         Label label1;
         root.addRow(1, new Label("default"), defaultSpinner, label1 = LabelBuilder.create().build());
 //        label1.textProperty().bind(Bindings.convert(defaultSpinner.numberProperty()));
@@ -101,10 +102,11 @@ public class BigDecimalFieldDemo extends Application {
                 percent.setNumber(new BigDecimal(Math.random()));
                 localizedCurrency.setNumber(new BigDecimal(Math.random() * 1000));
                 disabledField.setNumber(new BigDecimal(Math.random() * 1000));
+                promptText.clear();
 //                defaultSpinner.dumpSizes();
             }
         });
-        root.addRow(7, new Label(), button);
+        root.addRow(8, new Label(), button);
 
         Scene scene = new Scene(root);
 //        String path = NumberSpinnerDemo2.class.getResource("number_spinner.css").toExternalForm();


### PR DESCRIPTION
Working with JFX2, I liked the ability to use prompt texts instead of labels.
When I found you BigDecimalField, I was delighted to see that it solved the problem we were working at in a more thorough way, but unfortunately, there was no prompt text.

This change enables the BigDecimalField to show a prompt text when no value is entered.
It adds an API to clear the field, resetting it to 0 and showing the prompt text.
