### PR TITLE
fix for issue #50: https://github.com/JFXtras/jfxtras-labs/issues/50

### DIFF
--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/AgendaBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/AgendaBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.Agenda;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,6 +48,6 @@ public class AgendaBehavior extends BehaviorBase<Agenda>
 	 */
 	public AgendaBehavior(Agenda control)
 	{
-		super(control);
+		super(control, new ArrayList<KeyBinding>());
 	}
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/BatteryBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/BatteryBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.Battery;
 
 
@@ -40,7 +42,7 @@ import jfxtras.labs.scene.control.gauge.Battery;
 public class BatteryBehavior extends BehaviorBase<Battery> {
 
     public BatteryBehavior(final Battery CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }
 

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/BigDecimalFieldBehaviour.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/BigDecimalFieldBehaviour.java
@@ -30,6 +30,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.BigDecimalField;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * KeyBindings for the {@link BigDecimalField}.
@@ -38,7 +40,7 @@ import com.sun.javafx.scene.control.behavior.BehaviorBase;
 public class BigDecimalFieldBehaviour extends BehaviorBase<BigDecimalField> {
 
 	public BigDecimalFieldBehaviour(BigDecimalField control) {
-		super(control);
+		super(control, new ArrayList<KeyBinding>());
 	}
 
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarPickerBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarPickerBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.CalendarPicker;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,6 +48,6 @@ public class CalendarPickerBehavior extends BehaviorBase<CalendarPicker>
 	 */
 	public CalendarPickerBehavior(CalendarPicker control)
 	{
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 	}
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTextFieldBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTextFieldBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.CalendarTextField;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,7 +48,7 @@ public class CalendarTextFieldBehavior extends BehaviorBase<CalendarTextField>
 	 */
 	public CalendarTextFieldBehavior(CalendarTextField control)
 	{
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 		construct();
 	}
 	

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTimePickerBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTimePickerBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.CalendarTimePicker;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,6 +48,6 @@ public class CalendarTimePickerBehavior extends BehaviorBase<CalendarTimePicker>
 	 */
 	public CalendarTimePickerBehavior(CalendarTimePicker control)
 	{
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 	}
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTimeTextFieldBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/CalendarTimeTextFieldBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.CalendarTimeTextField;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,7 +48,7 @@ public class CalendarTimeTextFieldBehavior extends BehaviorBase<CalendarTimeText
 	 */
 	public CalendarTimeTextFieldBehavior(CalendarTimeTextField control)
 	{
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 		construct();
 	}
 	

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/ClockBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/ClockBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.Clock;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.Clock;
 public class ClockBehavior extends BehaviorBase<Clock> {
 
     public ClockBehavior(final Clock CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/DotMatrixSegmentBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/DotMatrixSegmentBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.DotMatrixSegment;
 
 
@@ -40,7 +42,7 @@ import jfxtras.labs.scene.control.gauge.DotMatrixSegment;
 public class DotMatrixSegmentBehavior extends BehaviorBase<DotMatrixSegment> {
 
     public DotMatrixSegmentBehavior(final DotMatrixSegment CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }
 

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/GaugeBehaviorBase.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/GaugeBehaviorBase.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.Gauge;
 import javafx.scene.input.MouseEvent;
 
@@ -42,7 +44,7 @@ public class GaugeBehaviorBase<C extends Gauge> extends BehaviorBase<C> {
 
     // ******************** Constructors **************************************
     public GaugeBehaviorBase(final C CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 
 

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/GridCellBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/GridCellBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.grid.GridCell;
 
 import com.sun.javafx.scene.control.behavior.CellBehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -37,6 +39,6 @@ import com.sun.javafx.scene.control.behavior.CellBehaviorBase;
  */
 public class GridCellBehavior<T> extends CellBehaviorBase<GridCell<T>> {
 	public GridCellBehavior(GridCell<T> control) {
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 	}
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/GridViewBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/GridViewBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.grid.GridView;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -37,6 +39,6 @@ import com.sun.javafx.scene.control.behavior.BehaviorBase;
  */
 public class GridViewBehavior<T> extends BehaviorBase<GridView<T>> {
     public GridViewBehavior(GridView<T> control) {
-        super(control);
+        super(control,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/LedBargraphBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/LedBargraphBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.LedBargraph;
 
 
@@ -39,6 +41,6 @@ import jfxtras.labs.scene.control.gauge.LedBargraph;
  */
 public class LedBargraphBehavior extends BehaviorBase<LedBargraph> {
     public LedBargraphBehavior(final LedBargraph CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/LedBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/LedBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.Led;
 
 
@@ -39,6 +41,6 @@ import jfxtras.labs.scene.control.gauge.Led;
  */
 public class LedBehavior extends BehaviorBase<Led> {
     public LedBehavior(final Led CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/ListSpinnerBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/ListSpinnerBehavior.java
@@ -53,7 +53,7 @@ public class ListSpinnerBehavior<T> extends BehaviorBase<ListSpinner<T>>
 	 */
 	public ListSpinnerBehavior(ListSpinner<T> control)
 	{
-		super(control);
+		super(control,KEY_BINDINGS);
 		construct();
 	}
 	
@@ -146,11 +146,6 @@ public class ListSpinnerBehavior<T> extends BehaviorBase<ListSpinner<T>>
 		KEY_BINDINGS.add(new KeyBinding(KeyCode.LEFT, EVENT_PREVIOUS));
 		KEY_BINDINGS.add(new KeyBinding(KeyCode.RIGHT, EVENT_NEXT));
 		KEY_BINDINGS.addAll(TRAVERSAL_BINDINGS);
-	}
-	
-	@Override protected List<KeyBinding> createKeyBindings() 
-	{		
-		return KEY_BINDINGS;
 	}
 	
 	@Override protected void callAction(String name) {

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/LocalDatePickerBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/LocalDatePickerBehavior.java
@@ -29,6 +29,8 @@ package jfxtras.labs.internal.scene.control.behavior;
 import jfxtras.labs.scene.control.LocalDatePicker;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 
 /**
  * 
@@ -46,6 +48,6 @@ public class LocalDatePickerBehavior extends BehaviorBase<LocalDatePicker>
 	 */
 	public LocalDatePickerBehavior(LocalDatePicker control)
 	{
-		super(control);
+		super(control,new ArrayList<KeyBinding>());
 	}
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/MatrixPanelBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/MatrixPanelBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.MatrixPanel;
 
 
@@ -42,6 +44,6 @@ import jfxtras.labs.scene.control.gauge.MatrixPanel;
 public class MatrixPanelBehavior extends BehaviorBase<MatrixPanel> {
 
     public MatrixPanelBehavior(final MatrixPanel CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/NixieTubeBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/NixieTubeBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.NixieTube;
 
 
@@ -41,6 +43,6 @@ public class NixieTubeBehavior extends BehaviorBase<NixieTube> {
 
     // ******************** Constructors **************************************
     public NixieTubeBehavior(final NixieTube CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/OdometerBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/OdometerBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.Odometer;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.Odometer;
 public class OdometerBehavior extends BehaviorBase<Odometer> {
 
     public OdometerBehavior(final Odometer CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/RaterBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/RaterBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import javafx.scene.input.MouseEvent;
 import jfxtras.labs.internal.scene.control.skin.RaterSkin;
 import jfxtras.labs.scene.control.gauge.Rater;
@@ -42,7 +44,7 @@ import jfxtras.labs.scene.control.gauge.Rater;
 public class RaterBehavior extends BehaviorBase<Rater> {
 
     public RaterBehavior(final Rater CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 
     @Override public void mousePressed(final MouseEvent EVENT) {

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SevenSegmentBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SevenSegmentBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.SevenSegment;
 
 
@@ -40,7 +42,7 @@ import jfxtras.labs.scene.control.gauge.SevenSegment;
 public class SevenSegmentBehavior extends BehaviorBase<SevenSegment> {
 
     public SevenSegmentBehavior(final SevenSegment CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }
 

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SimpleBatteryBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SimpleBatteryBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.SimpleBattery;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.SimpleBattery;
 public class SimpleBatteryBehavior extends BehaviorBase<SimpleBattery> {
 
     public SimpleBatteryBehavior(final SimpleBattery CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SimpleIndicatorBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SimpleIndicatorBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.SimpleIndicator;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.SimpleIndicator;
 public class SimpleIndicatorBehavior extends BehaviorBase<SimpleIndicator> {
 
     public SimpleIndicatorBehavior(final SimpleIndicator CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SixteenSegmentBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SixteenSegmentBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.SixteenSegment;
 
 
@@ -40,7 +42,7 @@ import jfxtras.labs.scene.control.gauge.SixteenSegment;
 public class SixteenSegmentBehavior extends BehaviorBase<SixteenSegment> {
 
     public SixteenSegmentBehavior(final SixteenSegment CONTROL) {
-        super(CONTROL);
+        super(CONTROL, new ArrayList<KeyBinding>());
     }
 }
 

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SmallRadialBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SmallRadialBehavior.java
@@ -27,6 +27,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.SmallRadial;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.SmallRadial;
 public class SmallRadialBehavior extends BehaviorBase<SmallRadial> {
 
     public SmallRadialBehavior(final SmallRadial CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/SplitFlapBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/SplitFlapBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import javafx.scene.input.MouseEvent;
 import jfxtras.labs.internal.scene.control.skin.SplitFlapSkin;
 import jfxtras.labs.scene.control.gauge.SplitFlap;
@@ -42,6 +44,6 @@ import jfxtras.labs.scene.control.gauge.SplitFlap;
 public class SplitFlapBehavior extends BehaviorBase<SplitFlap> {
 
     public SplitFlapBehavior(final SplitFlap CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/StepIndicatorBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/StepIndicatorBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import javafx.scene.input.MouseEvent;
 import jfxtras.labs.internal.scene.control.skin.RaterSkin;
 import jfxtras.labs.scene.control.gauge.StepIndicator;
@@ -42,7 +44,7 @@ import jfxtras.labs.scene.control.gauge.StepIndicator;
 public class StepIndicatorBehavior extends BehaviorBase<StepIndicator> {
 
     public StepIndicatorBehavior(final StepIndicator CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 
     @Override public void mousePressed(final MouseEvent EVENT) {

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/TrafficLightBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/TrafficLightBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.TrafficLight;
 
 
@@ -40,6 +42,6 @@ import jfxtras.labs.scene.control.gauge.TrafficLight;
 public class TrafficLightBehavior extends BehaviorBase<TrafficLight> {
 
     public TrafficLightBehavior(final TrafficLight CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/behavior/XYControlBehavior.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/behavior/XYControlBehavior.java
@@ -28,6 +28,8 @@
 package jfxtras.labs.internal.scene.control.behavior;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import jfxtras.labs.scene.control.gauge.XYControl;
 
 
@@ -41,7 +43,7 @@ public class XYControlBehavior extends BehaviorBase<XYControl> {
     private XYControl control;
 
     public XYControlBehavior(final XYControl CONTROL) {
-        super(CONTROL);
+        super(CONTROL,new ArrayList<KeyBinding>());
         control = CONTROL;
     }
 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/BreadcrumbBarSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/BreadcrumbBarSkin.java
@@ -27,7 +27,8 @@
 package jfxtras.labs.internal.scene.control.skin;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import javafx.scene.control.SkinBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
+import java.util.ArrayList;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ListChangeListener.Change;
 import javafx.scene.layout.HBox;
@@ -43,7 +44,7 @@ public class BreadcrumbBarSkin extends com.sun.javafx.scene.control.skin.Behavio
     private HBox itemsBox = new HBox();
 
     public BreadcrumbBarSkin(BreadcrumbBar c) {
-        super(c, new BehaviorBase<BreadcrumbBar>(c));
+        super(c, new BehaviorBase<BreadcrumbBar>(c,new ArrayList<KeyBinding>()));
 
         c.itemsProperty().get().addListener(new ListChangeListener<BreadcrumbItem>() {
             @Override
@@ -51,7 +52,7 @@ public class BreadcrumbBarSkin extends com.sun.javafx.scene.control.skin.Behavio
                 while (c.next()) {
                     if (c.wasRemoved()) {
                         itemsBox.getChildren().removeAll(c.getRemoved());
-                    } else if(c.wasAdded()) {
+                    } else if (c.wasAdded()) {
                         itemsBox.getChildren().addAll(c.getAddedSubList());
                     }
                 }

--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/BreadcrumbItemSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/BreadcrumbItemSkin.java
@@ -27,6 +27,7 @@
 package jfxtras.labs.internal.scene.control.skin;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.KeyBinding;
 import javafx.scene.control.SkinBase;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +76,7 @@ public class BreadcrumbItemSkin extends com.sun.javafx.scene.control.skin.Behavi
     }
     
     public BreadcrumbItemSkin(BreadcrumbItem c) {
-        super(c, new BehaviorBase<BreadcrumbItem>(c));
+        super(c, new BehaviorBase<BreadcrumbItem>(c,new ArrayList<KeyBinding>()));
 
         HBox box = new HBox();
         


### PR DESCRIPTION
fix for issue #50

constructor in `BehaviorBase` has changed. Instead of providing a method

```
@Override
public List<KeyBinding> getKeyBindings()  {
    // ...
}
```

key bindings are a constructor argument.

Example:

```
public class SixteenSegmentBehavior extends BehaviorBase<SixteenSegment> {

  public SixteenSegmentBehavior(final SixteenSegment CONTROL) {
    super(CONTROL);
  }
}
```

must be changed to

```
public class SixteenSegmentBehavior extends BehaviorBase<SixteenSegment> {

  public SixteenSegmentBehavior(final SixteenSegment CONTROL) {
    super(CONTROL, new ArrayList<KeyBinding>());
  }
}
```
