### PR TITLE
Adding continuous integration using travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ before_install:
   - "export DISPLAY=:99.0"
   - "export TERM=dumb"
   - "sh -e /etc/init.d/xvfb start"
+script: gradle clean check --info
+after_script:
+  - "cat ./build/test-results/*.xml"
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 before_install:
   - "export DISPLAY=:99.0"
+  - "export TERM=dumb"
   - "sh -e /etc/init.d/xvfb start"
 jdk:
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ before_install:
   - "export DISPLAY=:99.0"
   - "export TERM=dumb"
   - "sh -e /etc/init.d/xvfb start"
-script: gradle clean check --info
-after_script:
+script: gradle check --info
+after_failure:
   - "cat ./build/test-results/*.xml"
 jdk:
-  - oraclejdk7
+  - oraclejdk7  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 jdk:
   - oraclejdk7

--- a/src/test/java/jfxtras/labs/JavaFXPlatformAbstractTest.java
+++ b/src/test/java/jfxtras/labs/JavaFXPlatformAbstractTest.java
@@ -1,0 +1,25 @@
+package jfxtras.labs;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.embed.swing.JFXPanel;
+
+import javax.swing.SwingUtilities;
+
+import org.junit.BeforeClass;
+
+public class JavaFXPlatformAbstractTest {
+    @BeforeClass public static final void initJavaFXPlatform() {
+        final CountDownLatch latch = new CountDownLatch(1);
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                new JFXPanel(); // initializes JavaFX environment
+                latch.countDown();
+            }
+        });
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+        }
+    }
+}

--- a/src/test/java/jfxtras/labs/map/tile/TileRepositoryTest.java
+++ b/src/test/java/jfxtras/labs/map/tile/TileRepositoryTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import javafx.scene.image.ImageView;
+import jfxtras.labs.JavaFXPlatformAbstractTest;
 import jfxtras.labs.map.ApiKeys;
 import jfxtras.labs.map.tile.bing.BingTileSourceFactory;
 import jfxtras.labs.map.tile.bing.BingType;
@@ -40,6 +41,7 @@ import jfxtras.labs.map.tile.local.LocalTileSourceFactory;
 import jfxtras.labs.map.tile.osm.OsmTileSourceFactory;
 import jfxtras.labs.map.tile.osm.OsmType;
 
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -48,8 +50,7 @@ import org.junit.Test;
  * @author Mario Schroeder
  * 
  */
-public class TileRepositoryTest {
-	
+public class TileRepositoryTest extends JavaFXPlatformAbstractTest {
     @Test
     public void testWithNull(){
         

--- a/src/test/java/jfxtras/labs/map/tile/attribution/BingAttributionLoaderTest.java
+++ b/src/test/java/jfxtras/labs/map/tile/attribution/BingAttributionLoaderTest.java
@@ -29,8 +29,14 @@
 
 package jfxtras.labs.map.tile.attribution;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
+import jfxtras.labs.JavaFXPlatformAbstractTest;
 import jfxtras.labs.map.ApiKeys;
 import jfxtras.labs.map.tile.Attribution;
 import jfxtras.labs.map.tile.bing.BingAttributionLoader;
@@ -38,16 +44,14 @@ import jfxtras.labs.map.tile.bing.BingImageMetaDataHandler;
 import jfxtras.labs.map.tile.bing.BingMapMetaDataHandler;
 import jfxtras.labs.map.tile.bing.BingMetaDataHandler;
 
+import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  *
  * @author Mario Schroeder
  */
-public class BingAttributionLoaderTest {
-
+public class BingAttributionLoaderTest extends JavaFXPlatformAbstractTest {
     /**
      * Test of load method, of class BingAttributionLoader.
      */


### PR DESCRIPTION
Addition of .travis.yml in order to integrate travis-ci infrastructure.
What would be required then would be to link a travis account to the Github JFXtras/jfxtras-labs repository. This must be done by a member of the JFXtras community github project because right access is required so that Travis can register a pull hook. I would be able to do it I think if someone could add me to the JFXtras github community.

The build from travis is correctly working as shown on the ci-build of my fork : https://travis-ci.org/McFoggy/jfxtras-labs

Next step would be then to add automatic snapshot deployment, but it is another story.
