### PR TITLE
Conditional disabling of calendar days after instantiation

### DIFF
--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
@@ -599,7 +599,12 @@ public class CalendarPickerControlSkin extends CalendarPickerMonthlySkinAbstract
 		
 		// set the month buttons
 		int lDaysInMonth = determineDaysInMonth();
+		List<Integer> lDisabledDays = Collections.emptyList();
 		Calendar lCalendar = (Calendar)getDisplayedCalendar().clone();
+		if(getSkinnable().hasDisableCallback())
+		{
+			lDisabledDays = getSkinnable().getDisableCallback().call(lCalendar);
+		}
 		for (int i = 1; i <= lDaysInMonth; i++)
 		{
 			// set the date
@@ -629,11 +634,8 @@ public class CalendarPickerControlSkin extends CalendarPickerMonthlySkinAbstract
 				lToggleButton.getStyleClass().remove("today");
 			}
 			
-			// disable button according to callback return value
-			if(getSkinnable().hasDisableCallback())
-			{
-				lToggleButton.setDisable(getSkinnable().getDisableCallback().call(lCalendar));
-			}
+			// disable button if the day is in the list of disabled days
+			lToggleButton.setDisable(lDisabledDays.contains(lCalendar.get(java.util.Calendar.DATE)));
 		}
 
 		// hide the trailing buttons

--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
@@ -580,7 +580,7 @@ public class CalendarPickerControlSkin extends CalendarPickerMonthlySkinAbstract
 	/*
 	 * 
 	 */
-	private void refreshDayButtonsVisibilityAndLabel()
+	public void refreshDayButtonsVisibilityAndLabel()
 	{
 		// setup the buttons [0..(6*7)-1]
 		// displayed calendar always points to the 1st of the month
@@ -627,6 +627,12 @@ public class CalendarPickerControlSkin extends CalendarPickerMonthlySkinAbstract
 			else
 			{
 				lToggleButton.getStyleClass().remove("today");
+			}
+			
+			// disable button according to callback return value
+			if(getSkinnable().hasDisableCallback())
+			{
+				lToggleButton.setDisable(getSkinnable().getDisableCallback().call(lCalendar));
 			}
 		}
 

--- a/src/main/java/jfxtras/labs/scene/control/CalendarPicker.java
+++ b/src/main/java/jfxtras/labs/scene/control/CalendarPicker.java
@@ -45,6 +45,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Control;
+import javafx.util.Callback;
 
 /**
  * Calendar picker component
@@ -236,10 +237,16 @@ public class CalendarPicker extends Control
     public boolean getAllowNull() { return allowNullProperty.get(); }
     public void setAllowNull(boolean allowNull) { allowNullProperty.set(allowNull); }
     public CalendarPicker withAllowNull(boolean value) { setAllowNull(value); return this; }
+    
+    /** callback to disable calendar items */
+    private Callback<Calendar, Boolean> disableCallback;
+	public Callback<Calendar, Boolean> getDisableCallback() { return disableCallback; }
+	public void setDisableCallback(Callback<Calendar, Boolean> disableCallback) { this.disableCallback = disableCallback; }
+    public boolean hasDisableCallback() { return disableCallback != null; }
 
 	// ==================================================================================================================
 	// SUPPORT
-	
+    
 	/**
 	 * 
 	 */

--- a/src/main/java/jfxtras/labs/scene/control/CalendarPicker.java
+++ b/src/main/java/jfxtras/labs/scene/control/CalendarPicker.java
@@ -239,9 +239,9 @@ public class CalendarPicker extends Control
     public CalendarPicker withAllowNull(boolean value) { setAllowNull(value); return this; }
     
     /** callback to disable calendar items */
-    private Callback<Calendar, Boolean> disableCallback;
-	public Callback<Calendar, Boolean> getDisableCallback() { return disableCallback; }
-	public void setDisableCallback(Callback<Calendar, Boolean> disableCallback) { this.disableCallback = disableCallback; }
+    private Callback<Calendar, List<Integer>> disableCallback;
+	public Callback<Calendar, List<Integer>> getDisableCallback() { return disableCallback; }
+	public void setDisableCallback(Callback<Calendar, List<Integer>> disableCallback) { this.disableCallback = disableCallback; }
     public boolean hasDisableCallback() { return disableCallback != null; }
 
 	// ==================================================================================================================


### PR DESCRIPTION
We needed a way to disable the days in the calendar after the DatePicker is instantiated. To support disabling the days in general, we added a callback that takes as parameter the Calendar representing the day and returns a boolean that is set to true if the day should be disabled and false otherwise. The callback is executed in the CalendarPickerControlSkin.java within the refreshDayButtonsVisibilityAndLabel() method, which is responsible for decorating the days. To support disabling the days 'after' instantiation, we made the aforementioned method public so that it can directly be called without instantiating a new DatePicker. 
