### PR TITLE
Added BeanPathAdapter bean property

### DIFF
--- a/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
+++ b/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
@@ -615,6 +615,23 @@ public class BeanPathAdapter<B> {
 		}
 	}
 
+	private final ObjectProperty<B>  beanProp = new SimpleObjectProperty<>();
+	{
+		beanProp.addListener( new ChangeListener<B>()
+		{
+			@Override
+			public void changed( ObservableValue<? extends B> observable, B oldValue, B newValue )
+			{
+				setBean( newValue );
+			}
+		} );
+	}
+	
+	public ObjectProperty<B> beanProperty()
+	{
+		return beanProp; 
+	}
+
 	/**
 	 * @return the root/top level {@link FieldBean}
 	 */

--- a/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
+++ b/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
@@ -600,19 +600,7 @@ public class BeanPathAdapter<B> {
 	 *            the bean to set
 	 */
 	public void setBean(final B bean) {
-		if (bean == null) {
-			throw new NullPointerException();
-		}
-		if (getRoot() == null) {
-			this.root = new FieldBean<>(null, bean, null,
-					fieldPathValueProperty, dateFormatProperty());
-		} else {
-			getRoot().setBean(bean);
-		}
-		if (hasFieldPathValueTypes(FieldPathValueType.BEAN_CHANGE)) {
-			fieldPathValueProperty.set(new FieldPathValue(null, getBean(),
-					getBean(), FieldPathValueType.BEAN_CHANGE));
-		}
+		beanProp.set( bean );
 	}
 
 	private final ObjectProperty<B>  beanProp = new SimpleObjectProperty<>();
@@ -622,7 +610,19 @@ public class BeanPathAdapter<B> {
 			@Override
 			public void changed( ObservableValue<? extends B> observable, B oldValue, B newValue )
 			{
-				setBean( newValue );
+				if (bean == null) {
+					throw new NullPointerException();
+				}
+				if (getRoot() == null) {
+					this.root = new FieldBean<>(null, bean, null,
+							fieldPathValueProperty, dateFormatProperty());
+				} else {
+					getRoot().setBean(bean);
+				}
+				if (hasFieldPathValueTypes(FieldPathValueType.BEAN_CHANGE)) {
+					fieldPathValueProperty.set(new FieldPathValue(null, getBean(),
+							getBean(), FieldPathValueType.BEAN_CHANGE));
+				}
 			}
 		} );
 	}

--- a/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
+++ b/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
@@ -614,7 +614,7 @@ public class BeanPathAdapter<B> {
 					throw new NullPointerException();
 				}
 				if (getRoot() == null) {
-					this.root = new FieldBean<>(null, newBean, null,
+					BeanPathAdapter.this.root = new FieldBean<>(null, newBean, null,
 							fieldPathValueProperty, dateFormatProperty());
 				} else {
 					getRoot().setBean(newBean);

--- a/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
+++ b/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
@@ -608,16 +608,16 @@ public class BeanPathAdapter<B> {
 		beanProp.addListener( new ChangeListener<B>()
 		{
 			@Override
-			public void changed( ObservableValue<? extends B> observable, B oldValue, B newValue )
+			public void changed( ObservableValue<? extends B> observable, B oldBean, B newBean )
 			{
-				if (bean == null) {
+				if (newBean == null) {
 					throw new NullPointerException();
 				}
 				if (getRoot() == null) {
-					this.root = new FieldBean<>(null, bean, null,
+					this.root = new FieldBean<>(null, newBean, null,
 							fieldPathValueProperty, dateFormatProperty());
 				} else {
-					getRoot().setBean(bean);
+					getRoot().setBean(newBean);
 				}
 				if (hasFieldPathValueTypes(FieldPathValueType.BEAN_CHANGE)) {
 					fieldPathValueProperty.set(new FieldPathValue(null, getBean(),


### PR DESCRIPTION
Added beanProperty() method to facilitate the binding of a BeanPathAdapter to for instance a selection model. See here for an example http://stackoverflow.com/a/20656273/3110608
