### PR TITLE
Styling for today

### DIFF
--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/CalendarPickerControlSkin.java
@@ -808,13 +808,10 @@ public class CalendarPickerControlSkin extends CalendarPickerMonthlySkinAbstract
 			weeknumberLabels.get(lIdx / 7).setVisible(true);
 
 			// highlight today
+			lToggleButton.getStyleClass().remove("today");
 			if (isToday(lCalendar))
 			{
 				lToggleButton.getStyleClass().add("today");
-			}	
-			else
-			{
-				lToggleButton.getStyleClass().remove("today");
 			}
 			
 			// highligh


### PR DESCRIPTION
When the CalendarPicker is constructed, the ControlSkin adds styling for today. If we call CalendarPicker.setCalendar for the same month, then the skin gets refreshed and it re-adds the styling 'today'. So, the day gets duplicate 'today's. Now, if we change the calendar (e.g. to one month before) then only one occurrence of 'today' is removed so the styling remains. We don't have this problem in normal days because skin always removes the styling first and re-adds it. This pull request is similar to that. We now always remove 'today' first and then re-add it if necessary. This way, duplicate styling would be prevented. I think the style 'highlight' also suffers from this problem so the same solution can be applied to that as well. The change does not impose any performance degradation as far as I can see.
