### PR TITLE
HeterogeneousBidirectionalBinder

### DIFF
--- a/src/main/java/jfxtras/labs/util/HeterogeneousBidirectionalBinder.java
+++ b/src/main/java/jfxtras/labs/util/HeterogeneousBidirectionalBinder.java
@@ -1,0 +1,173 @@
+package jfxtras.labs.util;
+
+import javafx.beans.WeakListener;
+import javafx.beans.property.Property;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+
+import java.lang.ref.WeakReference;
+import java.util.function.Function;
+
+/**
+ * A bidirectional object binding between two properties of different types.
+ * It is a bindER rather than bindING for two reasons:
+ * <ul>
+ *     <li> We can't extend the original BidirectionalBinding since it has a private constructor </li>
+ *     <li> It doesn't use static methods and it's a simple object you want to keep a reference around </li>
+ * </ul>
+ * The bind is effective from the constructor until unbind() is called. It is registered as a weaklistener to both properties.
+ * Created by carrknight on 4/26/14.
+ */
+public class HeterogeneousBidirectionalBinder<A,B> implements ChangeListener<Object>, WeakListener {
+
+    //the use of WeakReferences here is just to mimic BidirectionalBindings
+    private final WeakReference<Property<A>> propertyRef1;
+    private final WeakReference<Property<B>> propertyRef2;
+    //here i use Transformer from Apache collection, but that's just such a simple interface i
+    // can re-implement it without having to deal with dependencies
+    private final Function<A,B> transformer1To2;
+    private final Function<B,A> transformer2To1;
+
+    //flag to avoid infinite recursion
+    private boolean updating = false;
+
+
+
+    private final int cachedHashCode;
+
+    public HeterogeneousBidirectionalBinder(Property<A> property1, Property<B> property2,
+                                            Function<A, B> transformer1To2, Function<B, A> transformer2To1) {
+        initCheck(property1, property2,transformer1To2,transformer2To1);
+
+        propertyRef1 = new WeakReference<>(property1);
+        propertyRef2 = new WeakReference<>(property2);
+        this.transformer1To2 = transformer1To2;
+        this.transformer2To1 = transformer2To1;
+
+        //well, start listening
+        property1.setValue(transformer2To1.apply(property2.getValue()));
+        property1.addListener(this);
+        property2.addListener(this);
+
+
+        cachedHashCode = propertyRef1.hashCode() * propertyRef2.hashCode() * transformer1To2.hashCode() * transformer2To1.hashCode();
+    }
+
+    private void initCheck(Property<A> property1, Property<B> property2,
+                           Function<A, B> transformer1To2, Function<B, A> transformer2To1) {
+        if(property1 == property2 ||property1 == null || property2 == null )
+            throw new IllegalArgumentException("Properties must be different and null");
+        if(transformer1To2 == null || transformer2To1 == null  )
+            throw new IllegalArgumentException("Transformers can't be null!");
+
+
+    }
+
+    protected Property<A> getProperty1() {
+        return propertyRef1.get();
+    }
+
+    protected Property<B> getProperty2() {
+        return propertyRef2.get();
+    }
+
+
+    /**
+     * here i forego generics entirely. Unfortunately I can't implement two typed ChangeListener interfaces, so this is the second best.
+     * Admittely a far worse second, but hey.
+     */
+    @Override
+    public void changed(ObservableValue sourceProperty, Object oldValue, Object newValue) {
+        //this is basically copy-pasted from the javafx 8 source, commented at random by me
+        if (!updating) {  //flag updating spares us from infinite recursion
+            final Property<A> property1 = propertyRef1.get(); //get the two properties
+            final Property<B> property2 = propertyRef2.get();
+            if ((property1 == null) || (property2 == null)) {
+                if (property1 != null) {
+                    property1.removeListener(this); //don't bother listening if the other one is null
+                }
+                if (property2 != null) {
+                    property2.removeListener(this);
+                }
+            } else {
+                try {
+                    updating = true; //set updating to true to avoid infinite recursion
+                    if (property1 == sourceProperty) {
+                        //grab the value, cast it, transform it and apply it!
+                        A newTypedValue = (A) newValue;
+                        property2.setValue(transformer1To2.apply(newTypedValue));
+                    } else {
+                        B newTypedValue = (B) newValue;
+                        property1.setValue(transformer2To1.apply(newTypedValue));
+                    }
+                } catch (RuntimeException e) {
+                    //if we fail, grab the old value, cast it, transform it and apply it.
+                    if (property1 == sourceProperty) {
+                        B oldTypedValue = (B) oldValue;
+                        property1.setValue(transformer2To1.apply(oldTypedValue));
+                    } else {
+                        A oldTypedValue = (A) oldValue;
+                        property2.setValue(transformer1To2.apply(oldTypedValue));
+                    }
+                    throw new RuntimeException(
+                            "Bidirectional binding failed, setting to the previous value", e);
+                } finally {
+                    updating = false;
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public int hashCode() {
+        return cachedHashCode;
+    }
+
+
+    public void unbind(){
+
+        final Property<A> property1 = propertyRef1.get();
+        if(property1 != null)
+            property1.removeListener(this);
+
+        final Property<B> property2 = propertyRef2.get();
+        if(property2!= null)
+            property2.removeListener(this);
+    }
+
+    /**
+     * copy pasted from the javafx8 source code: http://hg.openjdk.java.net/openjfx/8/master/rt/file/f89b7dc932af/modules/base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+     * @return whether either property is null
+     */
+    @Override
+    public boolean wasGarbageCollected() {
+        return (getProperty1() == null) || (getProperty2() == null);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o;
+
+        /*
+         If I ever decide to build a parallel static structure like the original binders then I'll have to change
+          the equals(o) to some deep-equality like below.
+          The reason is that the static unbind() works by just calling removeListener(.) which in turn works through equals.
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HeterogeneousBidirectionalBinder that = (HeterogeneousBidirectionalBinder) o;
+
+        //if one is null and the other isn't
+        return Objects.equals(this.propertyRef1.get(),that.propertyRef1.get())
+                &&
+                Objects.equals(this.propertyRef2.get(),that.propertyRef2.get())
+                &&
+                Objects.equals(this.transformer1To2,that.transformer1To2)
+                &&
+                Objects.equals(this.transformer2To1,that.transformer2To1);
+*/
+    }
+}
+

--- a/src/test/java/jfxtras/labs/util/HeterogeneousBidirectionalBinderTest.java
+++ b/src/test/java/jfxtras/labs/util/HeterogeneousBidirectionalBinderTest.java
@@ -1,0 +1,106 @@
+package jfxtras.labs.util;
+
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+/**
+ * Created by carrknight on 4/26/14.
+ */
+public class HeterogeneousBidirectionalBinderTest {
+    private static enum TestEnum{ NEGATIVE,POSITIVE}
+
+    @Test
+    public void simpleBindingTest() throws Exception {
+        //binding an enum and a number
+        Property<TestEnum> enumProperty = new SimpleObjectProperty<>(TestEnum.NEGATIVE);
+        Property<Number> integerProperty = new SimpleIntegerProperty(10);
+        Function<Number,TestEnum> toEnum = number -> number.intValue()>=0 ? TestEnum.POSITIVE : TestEnum.NEGATIVE;
+        Function<TestEnum,Number> toNumber = testEnum -> testEnum.equals(TestEnum.POSITIVE) ? 1 : -1;
+        //create the binding
+        HeterogeneousBidirectionalBinder<TestEnum,Number> binder =
+                new HeterogeneousBidirectionalBinder<>(enumProperty,integerProperty,toNumber,toEnum);
+        //like the original double-binding, when binder is created the property1 is set to property 2
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+
+        //if i change the integer property, i will see enum property change
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+        integerProperty.setValue(5);
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.NEGATIVE,enumProperty.getValue());
+
+        //if I change the enum, i will change the integer
+        enumProperty.setValue(TestEnum.POSITIVE);
+        Assert.assertEquals(integerProperty.getValue().intValue(),1);
+        enumProperty.setValue(TestEnum.NEGATIVE);
+        Assert.assertEquals(integerProperty.getValue().intValue(),-1);
+
+        //if i unbind, this stops being true
+        binder.unbind(); //notice that it's not the static method that gets called
+        integerProperty.setValue(5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+        enumProperty.setValue(TestEnum.POSITIVE);
+        Assert.assertEquals(integerProperty.getValue().intValue(),5);
+
+
+    }
+
+    @Test
+    public void conflictingBinding() throws Exception {
+        //binding an enum and a number
+        Property<TestEnum> enumProperty = new SimpleObjectProperty<>(TestEnum.NEGATIVE);
+        Property<Number> integerProperty = new SimpleIntegerProperty(10);
+        //the usual transfomers
+        Function<Number, TestEnum> toEnum = number -> number.intValue() >= 0 ? TestEnum.POSITIVE : TestEnum.NEGATIVE;
+        Function<TestEnum, Number> toNumber = testEnum -> testEnum.equals(TestEnum.POSITIVE) ? 1 : -1;
+        //the inverse transformers.
+        Function<Number, TestEnum> toEnum2 = number -> number.intValue() < 0 ? TestEnum.POSITIVE : TestEnum.NEGATIVE;
+        Function<TestEnum, Number> toNumber2 = testEnum -> testEnum.equals(TestEnum.NEGATIVE) ? 1 : -1;
+        //create the binding
+        HeterogeneousBidirectionalBinder<TestEnum, Number> binder =
+                new HeterogeneousBidirectionalBinder<>(enumProperty, integerProperty, toNumber, toEnum);
+        //like the original double-binding, when binder is created the property1 is set to property 2
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+
+        //if i change the integer property, i will see enum property change
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+        integerProperty.setValue(5);
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+
+        binder.unbind();
+        HeterogeneousBidirectionalBinder<TestEnum, Number> binder2 =
+                new HeterogeneousBidirectionalBinder<>(enumProperty, integerProperty, toNumber2, toEnum2);
+        integerProperty.setValue(5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+
+
+
+        HeterogeneousBidirectionalBinder<TestEnum, Number> binder3 =
+                new HeterogeneousBidirectionalBinder<>(enumProperty, integerProperty, toNumber, toEnum);
+        binder2.unbind();
+        binder.unbind(); //this is ignored. Notice that this is the big difference with the Bindings class since that uses
+        //statics all over the place and is forced to use deep equals to unbind correctly.
+
+        integerProperty.setValue(5);
+        Assert.assertEquals(TestEnum.POSITIVE, enumProperty.getValue());
+        integerProperty.setValue(-5);
+        Assert.assertEquals(TestEnum.NEGATIVE, enumProperty.getValue());
+
+
+
+
+
+    }
+
+}


### PR DESCRIPTION
This is something of a prototype. It works and is tested. I found it useful in my fx project. Hopefully you'll think it's useful for yours.

BidirectionalBinding only works between two properties of the same type. I'd like Property< A > and Property< B > to be bound bidirectionally even if A and B are different.
I created a simple "binder" that listens to the changes in  one property and updates the other. This way the two properties are bound.

The main weakness is that, while it works as the others BidirectionalBinding object, it doesn't extend the original class. The original class has private constructors. Moreover the original class works mostly by static methods in a, IMHO, very ugly fashion. 
I think this BindER works more intuitively without static methods.

An example of when I needed to use this for my project is the following.
I have an ENUM describing the "mouse mode" over a certain node. Whether SELECT/DELETE/EDIT. Then I have a toggle button group where the user can change the mouse-mode. So obviously the mouse mode needs to be bound to the toggle group. But the mouse-mode can be changed also by key short-cuts, and I'd like the toggle group to notice. So a Property< Toggle > and a Property< Mode > needed to be bound bidirectionally.
This binder solved this for me. 
