### PR TITLE
BigDecimalField handle currency formatted text replacement

### DIFF
--- a/src/main/java/jfxtras/labs/internal/scene/control/skin/BigDecimalFieldSkin.java
+++ b/src/main/java/jfxtras/labs/internal/scene/control/skin/BigDecimalFieldSkin.java
@@ -54,6 +54,7 @@ import jfxtras.labs.scene.control.BigDecimalField;
 
 import java.math.BigDecimal;
 import java.text.ParseException;
+import java.text.ParsePosition;
 
 
 /**
@@ -221,6 +222,7 @@ public class BigDecimalFieldSkin extends SkinBase<BigDecimalField> {
      */
     public class NumberTextField extends javafx.scene.control.TextField {
 
+        ParsePosition parsePosition = new ParsePosition(0);
         public NumberTextField() {
             getStyleClass().add("number-text-field");
             initHandlers();
@@ -286,18 +288,26 @@ public class BigDecimalFieldSkin extends SkinBase<BigDecimalField> {
                     CONTROL.setNumber(null);
                     return;
                 }
-                Number parsedNumber = CONTROL.getFormat().parse(input);
-                BigDecimal newValue = new BigDecimal(parsedNumber.toString());
+                Number parsedNumber = CONTROL.getFormat().parse(input, parsePosition);
+                BigDecimal newValue = null;
+                if (input.length() == parsePosition.getIndex()) {
+                    // matched the format
+                    newValue = new BigDecimal(parsedNumber.toString());
+                } else {
+                    // didn't match the format, it may not need formatting
+                    newValue = new BigDecimal(input);
+                }
                 // if parsing succeeded change number in Controller
                 CONTROL.setNumber(newValue);
                 selectAll();
-            } catch (ParseException ex) {
-                // If parsing fails keep old number
-                setText(CONTROL.getText());
             } catch (IllegalArgumentException ex) {
+                // If parsing fails keep old number
+                // OR
                 // If minValue and/or maxValue are set and the new number is out of these bounds
                 // keep also the old number
                 setText(CONTROL.getText());
+            } finally {
+                parsePosition.setIndex(0);
             }
         }
 

--- a/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
+++ b/src/test/java/jfxtras/labs/scene/control/BigDecimalFieldDemo.java
@@ -84,8 +84,10 @@ public class BigDecimalFieldDemo extends Application {
         final BigDecimalField percent = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.01"), NumberFormat.getPercentInstance());
         final BigDecimalField localizedCurrency = new BigDecimalField(BigDecimal.ZERO, new BigDecimal("0.01"), NumberFormat.getCurrencyInstance(Locale.UK));
         final BigDecimalField promptText = new BigDecimalField();
+        final BigDecimalField cssStyled = new BigDecimalField();
         promptText.setNumber(null);
         promptText.setPromptText("Enter something");
+        cssStyled.getStyleClass().add("css-styled");
         int rowIndex = 1;
         root.addRow(rowIndex++, new Label("default"), defaultSpinner);
         root.addRow(rowIndex++, new Label("custom decimal format"), decimalFormat);
@@ -96,6 +98,7 @@ public class BigDecimalFieldDemo extends Application {
         root.addRow(rowIndex++, new Label("disabled field"), disabledField);
         root.addRow(rowIndex++, new Label("regular TextField"), new TextField("1.000,1234"));
         root.addRow(rowIndex++, new Label("with promptText"), promptText);
+        root.addRow(rowIndex++, new Label("with CSS styling"), cssStyled);
         CalendarTextField calendarTextField = new CalendarTextField();
         root.addRow(rowIndex++, new Label("CalendarTextField"), calendarTextField);
         ComboBox<Locale> cmbLocales = new ComboBox<>(FXCollections.observableArrayList(Locale.GERMANY, Locale.UK, Locale.FRANCE));
@@ -130,6 +133,7 @@ public class BigDecimalFieldDemo extends Application {
             localizedCurrency.setNumber(new BigDecimal(Math.random() * 1000));
             disabledField.setNumber(new BigDecimal(Math.random() * 1000));
             promptText.setNumber(null);
+            cssStyled.setNumber(new BigDecimal(Math.random() * 1000));
             calendarTextField.setCalendar(Calendar.getInstance());
             decimalFormat.requestFocus();
         });
@@ -153,6 +157,7 @@ public class BigDecimalFieldDemo extends Application {
         });
         decimalFormat.requestFocus();
         Scene scene = new Scene(root);
+        scene.getStylesheets().add("jfxtras/labs/scene/control/BigDecimalFieldDemo.css");
         primaryStage.setScene(scene);
         primaryStage.show();
     }

--- a/src/test/java/jfxtras/labs/scene/control/test/BigDecimalFieldTest.java
+++ b/src/test/java/jfxtras/labs/scene/control/test/BigDecimalFieldTest.java
@@ -58,18 +58,22 @@ public class BigDecimalFieldTest extends GuiTest {
         StackPane root = new StackPane();
 
         nf = NumberFormat.getNumberInstance(Locale.UK);
+        cf = NumberFormat.getCurrencyInstance(Locale.UK);
         nf.setMaximumFractionDigits(2);
         nf.setMinimumFractionDigits(2);
         bigDecimalField1 = new BigDecimalField(new BigDecimal(10), new BigDecimal(2), nf);
         bigDecimalField2 = new BigDecimalField(new BigDecimal(20), new BigDecimal(2), nf);
-        root.getChildren().addAll(new VBox(bigDecimalField1, bigDecimalField2));
+        bigDecimalField3 = new BigDecimalField(new BigDecimal(30), new BigDecimal(2), cf);
+        root.getChildren().addAll(new VBox(bigDecimalField1, bigDecimalField2, bigDecimalField3));
 
         return root;
     }
 
     BigDecimalField bigDecimalField1;
     BigDecimalField bigDecimalField2;
+    BigDecimalField bigDecimalField3;
     NumberFormat nf;
+    NumberFormat cf;
     private final String NUMBER = "12345.6789";
 
     @Test
@@ -105,6 +109,26 @@ public class BigDecimalFieldTest extends GuiTest {
         nf.setMinimumFractionDigits(3);
         bigDecimalField1.setFormat(nf);
         Assert.assertEquals("12.345,679", bigDecimalField1.getText());
+    }
+    
+    @Test
+    public void checkSpecialFormattingUpDown() {
+        Platform.runLater(() -> bigDecimalField3.requestFocus());
+        sleep(1, TimeUnit.SECONDS);
+        push(KeyCode.UP);
+        Assert.assertEquals("\u00A332.00", bigDecimalField3.getText());
+        push(KeyCode.DOWN);
+        push(KeyCode.DOWN);
+        Assert.assertEquals("\u00A328.00", bigDecimalField3.getText());
+    }
+    
+    @Test
+    public void checkSpecialFormatting() {
+        Platform.runLater(() -> bigDecimalField3.requestFocus());
+        sleep(1, TimeUnit.SECONDS);
+        type(NUMBER);
+        push(ENTER);
+        Assert.assertEquals("\u00A312,345.68", bigDecimalField3.getText());
     }
 
 }

--- a/src/test/resources/jfxtras/labs/scene/control/BigDecimalFieldDemo.css
+++ b/src/test/resources/jfxtras/labs/scene/control/BigDecimalFieldDemo.css
@@ -1,0 +1,20 @@
+/******************************************************************************
+ * Css file for demo of Big Decimal Control
+ * @author : Thomas Bolz
+ *
+ ******************************************************************************/
+
+// Big Decimal Field
+.css-styled.big-decimal-field{
+    -fx-effect: dropshadow(one-pass-box, grey, 10, .4, 2, 2);
+    -fx-background-radius: 20 20 20 20;
+}
+.css-styled.big-decimal-field .text-field {
+    -fx-background-radius: 20 0 0 20;
+}
+.css-styled.big-decimal-field .arrow-button-up{
+    -fx-background-radius: 0 20 0 0;
+}
+.css-styled.big-decimal-field .arrow-button-down{
+    -fx-background-radius: 0 0 20 0;
+}

--- a/src/test/resources/jfxtras/labs/scene/control/BigDecimalFieldDemo.css
+++ b/src/test/resources/jfxtras/labs/scene/control/BigDecimalFieldDemo.css
@@ -18,3 +18,9 @@
 .css-styled.big-decimal-field .arrow-button-down{
     -fx-background-radius: 0 0 20 0;
 }
+.big-decimal-field .spinner-arrow-up {
+    -fx-stroke: green;
+}
+.big-decimal-field .spinner-arrow-down {
+    -fx-stroke: red;
+}


### PR DESCRIPTION
Issue: When tabbing through a form and into a BigDecimalField, the user would normally just type in the desired number for the field. If the BigDecimalField has a currency format (i.e. $100.00), when the user types in a number (i.e. 150), it fails format validation and does not take the new number.

Solution: I have updated the BigDecimalField to check if the input matches the format. If it does, then it will use the format. If the input does not, then it attempts to directly input the number as a BigDecimal. If that throws an InvalidArgumentException, then it will revert back to the previous value (as with current logic).

Added two unit tests to validate the up/down with currency format as well as text replacement.

(Also included with this is adding a CSS styled BigDecimalField to the sample)
