### PR TITLE
Fix Multiple Selection Not Updated On setBean() called on BeanPathAdaprer

### DIFF
--- a/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
+++ b/src/main/java/jfxtras/labs/scene/control/BeanPathAdapter.java
@@ -1966,13 +1966,13 @@ public class BeanPathAdapter<B> {
 									oc);
 						} else {
 							final boolean wasColEmpty = col.isEmpty();
-							if (collectionSelectionModel == null
-									&& (!wasColEmpty || isDirty)) {
+							if (collectionSelectionModel != null) {
+								collectionSelectionModel.clearSelection();
+							} else if (!wasColEmpty || isDirty) {
 								oc.clear();
 								changed = true;
-							} else if (collectionSelectionModel == null) {
-								changed = syncCollectionValuesFromObservable(
-										col, oc);
+							} else {
+								changed = syncCollectionValuesFromObservable(col, oc);
 							}
 							if (!wasColEmpty) {
 								syncObservableFromCollectionValues(col, oc);
@@ -1985,13 +1985,13 @@ public class BeanPathAdapter<B> {
 									oc);
 						} else {
 							final boolean wasColEmpty = map.isEmpty();
-							if (collectionSelectionModel == null
-									&& (!wasColEmpty || isDirty)) {
+							if (collectionSelectionModel != null) {
+								collectionSelectionModel.clearSelection();
+							} else if (!wasColEmpty || isDirty) {
 								oc.clear();
 								changed = true;
-							} else if (collectionSelectionModel == null) {
-								changed = syncCollectionValuesFromObservable(
-										map, oc);
+							} else {
+								changed = syncCollectionValuesFromObservable(map, oc);
 							}
 							if (!wasColEmpty) {
 								syncObservableFromCollectionValues(map, oc);
@@ -2008,13 +2008,13 @@ public class BeanPathAdapter<B> {
 									oc);
 						} else {
 							final boolean wasColEmpty = col.isEmpty();
-							if (collectionSelectionModel == null
-									&& (!wasColEmpty || isDirty)) {
+							if (collectionSelectionModel != null) {
+								collectionSelectionModel.clearSelection();
+							} else if (!wasColEmpty || isDirty) {
 								oc.clear();
 								changed = true;
-							} else if (collectionSelectionModel == null) {
-								changed = syncCollectionValuesFromObservable(
-										col, oc);
+							} else {
+								changed = syncCollectionValuesFromObservable(col, oc);
 							}
 							if (!wasColEmpty) {
 								syncObservableFromCollectionValues(col, oc);
@@ -2027,13 +2027,13 @@ public class BeanPathAdapter<B> {
 									oc);
 						} else {
 							final boolean wasColEmpty = map.isEmpty();
-							if (collectionSelectionModel == null
-									&& (!wasColEmpty || isDirty)) {
+							if (collectionSelectionModel != null) {
+								collectionSelectionModel.clearSelection();
+							} else if (!wasColEmpty || isDirty) {
 								oc.clear();
 								changed = true;
-							} else if (collectionSelectionModel == null) {
-								changed = syncCollectionValuesFromObservable(
-										map, oc);
+							} else {
+								changed = syncCollectionValuesFromObservable(map, oc);
 							}
 							if (!wasColEmpty) {
 								syncObservableFromCollectionValues(map, oc);


### PR DESCRIPTION
If `BeanPathAdaptor#setBean` called, and a collection is bind to a
`SelectionModel` with `SelectionMode.MULTIPLE`, `BeanPathAdaptor`
did not deselect object that are not present in the original collection.

The clearing is done in `syncCollectionValues` method because we need
no selected values if the collection is empty